### PR TITLE
Add support for plain text, checkbox/multi-select, and asset fieldtypes

### DIFF
--- a/guestentriesemail/GuestEntriesEmailPlugin.php
+++ b/guestentriesemail/GuestEntriesEmailPlugin.php
@@ -52,7 +52,7 @@ class GuestEntriesEmailPlugin extends BasePlugin
             $fieldContent = " <br>";
 
             foreach($fieldValue->find() as $asset) {
-              $fieldContent .= '<a href="' . $asset->url . '">' . $asset->url . '</a>,<br>';
+              $fieldContent .= '<a href="' . $asset->getUrl() . '">' . $asset->getUrl() . '</a>,<br>';
             }
 
             $fieldContent = substr($fieldContent, 0, strlen($fieldContent) - 5);


### PR DESCRIPTION
This lets us have a little more robust contact form emails. It will now loop through plain text strings, arrays like checkboxes/multi-selects, and Assets fieldtypes. For Assets, it just lists links to the assets that were uploaded.
