### PR TITLE
Use section handle instead of entry type

### DIFF
--- a/guestentriesemail/GuestEntriesEmailPlugin.php
+++ b/guestentriesemail/GuestEntriesEmailPlugin.php
@@ -12,7 +12,7 @@ class GuestEntriesEmailPlugin extends BasePlugin
       $entryModel = $event->params['entry'];
       $sectionId = $entryModel['attributes']['sectionId'];
       $section = craft()->sections->getSectionById($sectionId);
-      $sectionHandle = $section['entryTypes'][0]['attributes']['handle'];
+      $sectionHandle = $section['handle'];
       
       // get settings
       //$settings = $this->getSettings();


### PR DESCRIPTION
This is needed in cases of sections having multiple entry types, since the settings only use the section handle