### PR TITLE
Use onsuccess event hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Craft – Guest Entries Email Notification
 Extend Pixel &amp; Tonic&rsquo;s [Guest Entries](https://github.com/pixelandtonic/GuestEntries/) plugin with email notifications.
 
-**NOTE: this plugin requires the Guest Entries plugin**
+**NOTE: this plugin requires the Guest Entries plugin version 1.5.0 or greater**
 
 ## Installation
 1. Upload the guestentriesemail/ folder to your craft/plugins/ folder.

--- a/guestentriesemail/GuestEntriesEmailPlugin.php
+++ b/guestentriesemail/GuestEntriesEmailPlugin.php
@@ -7,7 +7,7 @@ class GuestEntriesEmailPlugin extends BasePlugin
   
   public function init()
 	{
-  	craft()->on('guestEntries.beforeSave', function(GuestEntriesEvent $event) {
+  	craft()->on('guestEntries.onSuccess', function(GuestEntriesEvent $event) {
     	// get entry object
       $entryModel = $event->params['entry'];
       $sectionId = $entryModel['attributes']['sectionId'];


### PR DESCRIPTION
Guest Entries added onSuccess event hook with 1.5.0 - this will solve the problem of emails being sent when there was an error (like required fields missing)