### PR TITLE
Use htmlBody attribute

### DIFF
--- a/guestentriesemail/GuestEntriesEmailPlugin.php
+++ b/guestentriesemail/GuestEntriesEmailPlugin.php
@@ -56,7 +56,8 @@ class GuestEntriesEmailPlugin extends BasePlugin
             $email = new EmailModel();
             $email->toEmail = $value;
             $email->subject = $emailSubject;
-            $email->body    = $message;
+            $email->htmlBody = $message;
+            $email->body = strip_tags($message);
       
             craft()->email->sendEmail($email);
           }


### PR DESCRIPTION
This will prevent Craft from running the body (which has html) through MarkDown.